### PR TITLE
Use mousedown instead of click to avoid opening button press capture

### DIFF
--- a/src/components/useClickOutside.tsx
+++ b/src/components/useClickOutside.tsx
@@ -13,10 +13,10 @@ const useClickOutside = (
       callback();
     };
 
-    window.addEventListener("click", listener);
+    window.addEventListener("mousedown", listener);
 
     return () => {
-      window.removeEventListener("click", listener);
+      window.removeEventListener("mousedown", listener);
     };
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "noUnusedLocals": true
+    "noUnusedLocals": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Fixes: #10 