### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/mikefrancis/nosh/security/code-scanning/1](https://github.com/mikefrancis/nosh/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions` block that grants only the scopes needed by the workflow. For a simple end‑to‑end test workflow that just checks out code and runs Cypress against a started app, GITHUB_TOKEN typically only needs read access to repository contents, so `contents: read` at the workflow or job level is sufficient.

The best fix here, without changing existing behavior, is to add a root‑level `permissions` section (right after `name:` or `on:`) with `contents: read`. This will apply to all jobs in this workflow (currently only `e2e`) and clearly documents the intended minimal permissions. No changes to steps are required. Specifically, edit `.github/workflows/e2e.yml` to insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after `name: Test`). No additional imports, methods, or definitions are needed since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
